### PR TITLE
Replace `tibdex/github-app-token` by `actions/create-github-app-token`

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -15,11 +15,11 @@ jobs:
       pull-requests: write # To open a Pull Request
     steps:
     - name: Create token to create Pull Request
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
       id: automation-token
       with:
-        app_id: ${{ secrets.AUTOMATION_ID }}
-        private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
+        app-id: ${{ secrets.AUTOMATION_ID }}
+        private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
     - name: Update tooling
       uses: ericcornelissen/tool-versions-update-action/pr@1a22fed2aa6ac761cfd753c0b3db943b961b4484 # v1.1.5
       with:


### PR DESCRIPTION
Replaces the (unofficial) former action has been archived in favor of the (new and official) latter action.