### PR TITLE
Add tool `dockle`

### DIFF
--- a/.dockleignore
+++ b/.dockleignore
@@ -1,0 +1,16 @@
+# Configuration file for Dockle (https://github.com/goodwithtech/dockle)
+
+## root is fine in a dev image
+CIS-DI-0001
+
+## trust is unnecessary for local image
+CIS-DI-0005
+
+## dev image does not need a HEALTHCHECK
+CIS-DI-0006
+
+## latest is fine for a local image
+DKL-DI-0006
+
+## too many false positives
+DKL-LI-0003

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,6 +50,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-24.04
+    needs:
+    - dev-env
     steps:
     - name: Checkout repository
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,6 @@
 # Configuration file for asdf (https://asdf-vm.com/)
 actionlint 1.7.7
+dockle 0.4.15
 hadolint 2.14.0
 shellcheck 0.11.0
 shfmt 3.12.0

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -2,6 +2,8 @@
 
 FROM docker.io/golang:1.24.2-alpine3.21
 
+ENV ASDF_DIFFOCI_CONTAINER=1
+
 RUN apk add --no-cache \
 	# prerequisites
 	bash curl git make \
@@ -17,6 +19,7 @@ COPY .tool-versions .
 RUN go install github.com/asdf-vm/asdf/cmd/asdf@v0.16.2 \
 	&& echo 'export PATH="/.asdf/shims:$''PATH"' > ~/.bashrc \
 	&& asdf plugin add actionlint \
+	&& asdf plugin add dockle \
 	&& asdf plugin add hadolint \
 	&& asdf plugin add shellcheck \
 	&& asdf plugin add shfmt \

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,12 @@ dev-env: dev-img ## Run an ephemeral development environment container
 		asdf-diffoci-dev-img
 
 dev-img: ## Build a development environment image
+ifndef ASDF_DIFFOCI_CONTAINER
 	@docker build \
 		--tag asdf-diffoci-dev-img \
 		--file Containerfile.dev \
 		.
+endif
 
 .PHONY: format format-check
 format: ## Format the source code
@@ -49,8 +51,9 @@ lint-ci: $(ASDF) ## Lint CI workflow files
 	@SHELLCHECK_OPTS=$(SHELLCHECK_OPTS) \
 		actionlint
 
-lint-container: $(ASDF) ## Lint the Containerfile
+lint-container: $(ASDF) dev-img ## Lint the Containerfile
 	@hadolint Containerfile.dev
+	@[ -z "$$ASDF_DIFFOCI_CONTAINER" ] && dockle asdf-diffoci-dev-img || :
 
 lint-sh: ## Lint .sh files
 	@SHELLCHECK_OPTS=$(SHELLCHECK_OPTS) \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ lint-ci: $(ASDF) ## Lint CI workflow files
 
 lint-container: $(ASDF) dev-img ## Lint the Containerfile
 	@hadolint Containerfile.dev
-	@[ -z "$$ASDF_DIFFOCI_CONTAINER" ] && dockle asdf-diffoci-dev-img || :
+	@if [ -z "$$ASDF_DIFFOCI_CONTAINER" ]; then \
+		dockle --exit-code 1 --exit-level info asdf-diffoci-dev-img; \
+	fi
 
 lint-sh: ## Lint .sh files
 	@SHELLCHECK_OPTS=$(SHELLCHECK_OPTS) \


### PR DESCRIPTION
## Summary

Add [`dockle`](https://github.com/goodwithtech/dockle) as a tool dependency to lint the development container image.