### PR TITLE
Add check for diffoci GitHub Release immutability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ All notable changes to _asdf-diffoci_ will be documented in this file.
 
 ## Changes
 
+- (2026-04-06) Add GitHub Release immutability check.
 - (2025-04-20) Initial release.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Eric Cornelissen
+Copyright (c) 2025-2026 Eric Cornelissen
 Copyright (c) 2020 The asdf-vm core
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,9 +2,13 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/reproducible-containers/diffoci"
-TOOL_NAME="diffoci"
-TOOL_TEST="diffoci -version"
+REPO_NAME='reproducible-containers/diffoci'
+TOOL_NAME='diffoci'
+TOOL_TEST='diffoci -version'
+
+GH_REPO="https://github.com/${REPO_NAME}"
+GH_API_REPO="https://api.github.com/repos/${REPO_NAME}"
+GH_API_VERSION='2026-03-10'
 
 fail() {
 	echo -e "asdf-${TOOL_NAME}: $*"
@@ -59,18 +63,27 @@ list_all_versions() {
 }
 
 download_release() {
-	local version filename system arch url
+	local version filename system arch download_url metadata_url metadata immutable
 
 	version="$1"
 	filename="$2"
 
 	system="$(_system)" || fail 'Could not get the kernel name'
 	arch="$(_arch)" || fail 'Unknown machine (hardware) type'
-	url="${GH_REPO}/releases/download/v${version}/diffoci-v${version}.${system}-${arch}"
+	download_url="${GH_REPO}/releases/download/v${version}/diffoci-v${version}.${system}-${arch}"
 
 	echo "* Downloading ${TOOL_NAME} release ${version}..."
-	curl "${curl_opts[@]}" -o "${filename}" -C - "${url}" || fail "Could not download ${url}"
+	curl "${curl_opts[@]}" -o "${filename}" -C - "${download_url}" || fail "Could not download ${download_url}"
 	chmod +x "${filename}"
+
+	metadata_url="${GH_API_REPO}/releases/tags/v${version}"
+	metadata=$(curl "${curl_opts[@]}" -H 'Accept: application/vnd.github+json' -H "X-GitHub-Api-Version: ${GH_API_VERSION}" "${metadata_url}" 2>/dev/null || true)
+	if [[ -n ${metadata} ]]; then
+		immutable=$(echo "${metadata}" | grep '"immutable": true,' || true)
+		if [[ -z ${immutable} ]]; then
+			echo "! Release ${version} of ${TOOL_NAME} is NOT an 'Immutable release'"
+		fi
+	fi
 }
 
 install_version() {


### PR DESCRIPTION
Closes #67

## Summary

Update the downloading logic to check the release metadata of the specified release and inform(/warn) the user if the release is not immutable. The motivation for this check is that for a non-immutable release future downloads might result in a different binary (given the same platform) while this is not true for an immutable release (assuming GitHub is trusted).

This intentionally fails silently to avoid bugging the user about it when this _optional_ check fails.