### PR TITLE
ci: update Semgrep image to 1.168.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,7 +72,7 @@ jobs:
     permissions:
       security-events: write # To upload SARIF results
     container:
-      image: semgrep/semgrep:1.162.0
+      image: semgrep/semgrep:1.168.0
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Updated the Semgrep container image in `.github/workflows/check.yml` from `1.162.0` to `1.168.0`.

### Changelog (v1.162.0 to v1.168.0)

#### v1.168.0
- **Added**: Experimental `--x-dependency-paths` flag to include full dependency paths for transitive findings.
- **Changed**: Malicious supply chain rules are now labeled "Malicious".
- **Infra**: Removed dependency on `libpcre` 8.x; now exclusively uses `libpcre2` 10.x.

#### v1.167.0
- **Added**: Support for more operators in constant propagation folding.
- **Added**: `nosemgrep_disabled` field to scan configuration.
- **Changed**: Semgrep now skips binary files by default.

#### v1.166.0
- **Added**: (Pro) Experimental cross-file analysis for Gosu.
- **Fixed**: Various parsing and CI hook issues.

#### v1.165.0
- **Added**: `--max-match-context-size` option to limit source code context in output.
- **Changed**: Updated Python grammar and replaced rule validation flags.

#### v1.164.0
- **Added**: Enhanced Dart support (typed metavariables, string interpolation).
- **Changed**: Default memory limit for Pro scans now adapts to container limits.

#### v1.163.0
- **Added**: Support for PHP 8.1-8.5.
- **Changed**: Parallel rule validation and parsing to improve startup time.

#### v1.162.0
- **Added**: Improved support for tracking taint through nested functions.
- **Changed**: JSON rule parsing is up to 5x faster.
- **Fixed**: Credential redaction in CI log messages.

---
*PR created automatically by Jules for task [13290567495820952131](https://jules.google.com/task/13290567495820952131) started by @ericcornelissen*